### PR TITLE
feat(dev): Windows-friendly preview setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,5 @@ models/
 checkpoints/
 logs/
 wandb/
+# Generated analysis outputs
+results/

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -18,7 +18,7 @@ sys.path.append(str(Path(__file__).parent.parent / "src"))
 from utils.config import config
 from preprocessing.pipeline import PreprocessingPipeline
 from models.tokenizer import DNATokenizer
-from models.embeddings import DNATransformerEmbedder
+from models.embeddings_stub import DNATransformerEmbedder
 from models.trainer import EmbeddingTrainer
 from clustering.algorithms import EmbeddingClusterer
 from clustering.taxonomy import HybridTaxonomyAssigner, BlastTaxonomyAssigner, MLTaxonomyClassifier


### PR DESCRIPTION
- Make UMAP optional with PCA fallback in clustering
- Replace heavy torch-based trainer with lightweight stub
- Provide torch-free DNATransformerEmbedder stub and wire pipeline to it
- Keep models package init lightweight to avoid heavy imports
- Add results/ to .gitignore to prevent committing generated artifacts

This enables running the demo pipeline on Windows (Python 3.13) without installing GPU/torch or external tools, using mock embeddings and sklearn.